### PR TITLE
fix: add picomatch dependency

### DIFF
--- a/.changeset/lazy-jars-flash.md
+++ b/.changeset/lazy-jars-flash.md
@@ -1,0 +1,5 @@
+---
+"@sdk-usage/core": patch
+---
+
+Add `picomatch` as a dependency to allow standalone run of `sdk-usage`

--- a/libraries/core/package.json
+++ b/libraries/core/package.json
@@ -46,7 +46,8 @@
 	"dependencies": {
 		"@open-vanilla/visitor": "^1.0.0",
 		"@swc/core": "^1.9.2",
-		"fdir": "^6.4.2"
+		"fdir": "^6.4.2",
+		"picomatch": "^4.0.2"
 	},
 	"devDependencies": {
 		"@types/node": "22.9.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"check": "stack check",
 		"clean": "stack clean",
 		"fix": "stack fix",
+		"preinstall": "npx only-allow pnpm",
 		"prepare": "stack install",
 		"release:log": "stack release --log",
 		"release:publish": "stack release --publish",
@@ -23,8 +24,6 @@
 	"packageManager": "pnpm@9.15.0",
 	"engines": {
 		"node": ">=22.0.0",
-		"npm": "please-use-pnpm",
-		"pnpm": ">=9.0.0",
-		"yarn": "please-use-pnpm"
+		"pnpm": ">=9.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       fdir:
         specifier: ^6.4.2
         version: 6.4.2(picomatch@4.0.2)
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@types/node':
         specifier: 22.9.0


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Before requesting reviews, please make sure that:

  1. Your contribution follows coding conventions
  2. Some valuable tests have been added
  3. For non-internal change, a changelog entry is added

  Learn more about contributing [here](https://github.com/adbayb/sdk-usage/blob/main/CONTRIBUTING.md)
-->

## Description

- [x] Remove `npm` and `yarn` in `engines`
- [x] Add `preinstall` to enforce `pnpm` usage as [recommended on their doc](https://pnpm.io/only-allow-pnpm)
- [x] Add missing dependency of `picomatch` that will allow running `@sdk-usage/cli` as standalone using `pnpm dlx`

