### PR TITLE
feat: add resolveInstalledVersions option

### DIFF
--- a/.changeset/tough-feet-end.md
+++ b/.changeset/tough-feet-end.md
@@ -1,0 +1,5 @@
+---
+"@sdk-usage/core": minor
+---
+
+Add `resolveInstalledVersions` option with `false` as default. This option let the user choose between resolving installed version or the version from package.json.

--- a/libraries/core/src/createContext.ts
+++ b/libraries/core/src/createContext.ts
@@ -16,7 +16,7 @@ type Options = Partial<
 		 */
 		includeModules: string[];
 		/**
-		 * Whether to resolve installed versions of modules, if false or not possible, will use the version from the package.json.
+		 * Attempt to resolve installed versions of modules. If false or not possible, the specified version from the package.json will be used.
 		 * @default false
 		 */
 		resolveInstalledVersions: boolean;
@@ -54,7 +54,7 @@ export const createContext = (path: string, options: Options) => {
 								return;
 							}
 
-							let version: string;
+							let version = dependencies[item.module] ?? "";
 
 							if (options.resolveInstalledVersions) {
 								try {
@@ -68,10 +68,8 @@ export const createContext = (path: string, options: Options) => {
 										) as Package
 									).version;
 								} catch {
-									version = dependencies[item.module] ?? "";
+									// @TODO: No operation (later warnings can be added).
 								}
-							} else {
-								version = dependencies[item.module] ?? "";
 							}
 
 							items.push(

--- a/libraries/core/src/createContext.ts
+++ b/libraries/core/src/createContext.ts
@@ -15,6 +15,11 @@ type Options = Partial<
 		 * Only analyze components imported from the specificied module list.
 		 */
 		includeModules: string[];
+		/**
+		 * Whether to resolve installed versions of modules, if false or not possible, will use the version from the package.json.
+		 * @default false
+		 */
+		resolveInstalledVersions: boolean;
 	}
 > &
 	Pick<ParseOptions, "plugins">;
@@ -51,17 +56,21 @@ export const createContext = (path: string, options: Options) => {
 
 							let version: string;
 
-							try {
-								version = (
-									require(
-										resolvePackageJson(
-											require.resolve(item.module, {
-												paths: [file],
-											}),
-										),
-									) as Package
-								).version;
-							} catch {
+							if (options.resolveInstalledVersions) {
+								try {
+									version = (
+										require(
+											resolvePackageJson(
+												require.resolve(item.module, {
+													paths: [file],
+												}),
+											),
+										) as Package
+									).version;
+								} catch {
+									version = dependencies[item.module] ?? "";
+								}
+							} else {
 								version = dependencies[item.module] ?? "";
 							}
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Before requesting reviews, please make sure that:

  1. Your contribution follows coding conventions
  2. Some valuable tests have been added
  3. For non-internal change, a changelog entry is added

  Learn more about contributing [here](https://github.com/adbayb/sdk-usage/blob/main/CONTRIBUTING.md)
-->

## Description

- [x] Add `resolveInstalledVersions` option to choose between resolving installed version or package.json dependency version.

## Screenshots

| True | False |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/d21e01b6-980b-4a59-af90-4f5ac7163a2f)  | ![image](https://github.com/user-attachments/assets/605bc363-9052-43a7-b244-804092c9c6a6) |
